### PR TITLE
fix(scroll): incorrect nested scroll behaviour fix

### DIFF
--- a/lib/widgets/days_widget.dart
+++ b/lib/widgets/days_widget.dart
@@ -65,6 +65,7 @@ class DaysWidget extends StatelessWidget {
       padding: EdgeInsets.zero,
       crossAxisSpacing: calendarCrossAxisSpacing,
       mainAxisSpacing: calendarMainAxisSpacing,
+      primary: false,
       shrinkWrap: true,
       children: List.generate(
           DateTime(month.year, month.month + 1, 0).day + start, (index) {


### PR DESCRIPTION
in case the calendar is built inside the bottom sheet widget, not making the `GridView` for a `days_widget` as primary will prevent the calendar from scrolling up properly, as it will force the bottom sheet to close before user would be able to scroll the calendar.